### PR TITLE
Lighthouse | Оптимизация | SEO | Добавил CustomButton для атрибутов: ariaLabel, href

### DIFF
--- a/src/components/CartButton.jsx
+++ b/src/components/CartButton.jsx
@@ -4,7 +4,7 @@ import cx from 'classnames'
 import { NavLink } from 'react-router-dom'
 import M from 'materialize-css'
 import { useCookies } from 'react-cookie'
-import { CustomIcon, LoginButton, LanguageSelector, CopyLinkButton } from "./index";
+import { CustomFabButton, CustomIcon, LoginButton, LanguageSelector, CopyLinkButton } from "./index";
 import { useTranslation } from "react-i18next"
 
 const AddedProductsIndicator = props => {
@@ -35,17 +35,12 @@ const CartButton = () => {
 
     const disabledTextSelectionStyle={userSelect: "none", webUserSelect: "none" }
 
-    return <div style={{ position: "absolute" }}><Button
+    return <div style={{ position: "absolute" }}><CustomFabButton
         className={cx("blue darken-2", { pulse: cartSize })}
-        fab={{ direction: "top", hoverEnabled: false }}
-        floating
-        large
         icon={cartSize ? <>
             <AddedProductsIndicator>{cartSize}</AddedProductsIndicator>
             <CustomIcon style={disabledTextSelectionStyle}>shopping_cart</CustomIcon>
         </> : <CustomIcon style={disabledTextSelectionStyle} className={"notranslate"}>shopping_cart</CustomIcon>}
-        node="button"
-
     >
         <Button
             className="blue darken-2"
@@ -74,7 +69,7 @@ const CartButton = () => {
         <LanguageSelector />
         <LoginButton cardButton={true} />
         <CopyLinkButton/>
-    </Button></div>
+    </CustomFabButton></div>
 }
 
 export default CartButton

--- a/src/components/CustomMaterialize/CustomFabButton.js
+++ b/src/components/CustomMaterialize/CustomFabButton.js
@@ -1,0 +1,44 @@
+import React, { Children, useRef, useEffect } from 'react'
+import cx from 'classnames'
+import M from 'materialize-css'
+
+let id = 0
+
+const idgen = () => {
+    let oldId = id
+    id += 1
+    return oldId
+}
+
+const CustomFabButton = ({
+    children,
+    className,
+    icon,
+    ...props
+}) => {
+    const _fab = useRef(null)
+
+    useEffect(() => {
+        if (_fab.current) {
+            const instance = M.FloatingActionButton.init(_fab.current, true)
+            return () => instance && instance.destroy()
+        }
+    }, [])
+
+    return <div
+        {...props}
+        className='fixed-action-btn'
+        ref={_fab}
+    >
+        <button className={cx(className, "btn-floating", "btn-large")}>
+            {icon}
+        </button>
+        <ul>
+            {Children.map(children, child => (
+                <li key={idgen()}>{child}</li>
+            ))}
+        </ul>
+    </div>
+}
+
+export default CustomFabButton

--- a/src/components/PartialElements/LanguageSelector.jsx
+++ b/src/components/PartialElements/LanguageSelector.jsx
@@ -1,19 +1,20 @@
 import { useTranslation } from "react-i18next"
-import { Button } from "react-materialize"
 import React from 'react'
+import { Button } from 'react-materialize';
 import styles from "../../css.module/language.module.css"
 
 const LanguageSelector = () => {
 
     const { i18n } = useTranslation()
+    const label = i18n.language === "ua" ? "Змінити мову" : "Изменить язык"
 
     return <Button
+        ariaLabel={label}
         className={styles[i18n.language]}
-        tooltip={i18n.language === "ua" ? "Змінити мову" : "Изменить язык"}
+        tooltip={label}
         onClick={() => i18n.changeLanguage(i18n.language === "ua" ? "ru" : "ua")}
         tooltipOptions={{ position: 'left' }}
         floating
-        node="button"
     />
 }
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -5,6 +5,7 @@ export {default as ContactsPage}           from './ContactsPage/ContactsPage'
 export {default as CustomCard}             from './CustomMaterialize/CustomCard'
 export {default as CustomCardTitle}        from './CustomMaterialize/CustomCardTitle'
 export {default as CustomIcon}             from './CustomMaterialize/CustomIcon'
+export {default as CustomFabButton}        from './CustomMaterialize/CustomFabButton'
 
 export {default as ProductOptionSelect}    from './PartialElements/ProductOptionSelect'
 export {default as LoadingAnimation}       from './PartialElements/LoadingAnimation'


### PR DESCRIPTION
Создал кастомную компоненту CustomButton на основе Button из react-materialize-css.

У Button есть два варианта кнопки:
1 "простая" кнопка
2 "раскрывающаяся" кнопка (если добавить проп: "fab")

"Раскрывающаяся" кнопка является контейнером для списка кнопок, она сама никуда не переадрисовывает при нажатии, но внутри имеет тег "a",  у которого бот гугл пытается найти аргумент "href". Так как тег "a" использовался не по назначению он заменен на тег "button"

Цель: реализовать рекомендацию Lighthouse
До
![image](https://user-images.githubusercontent.com/49411370/189190581-1b32c260-b555-4592-9f08-573869ce3687.png)
В тесте "PC" accessibility
![image](https://user-images.githubusercontent.com/49411370/189190720-a2831812-adc9-4703-b190-72f0cb14c488.png)
После
![image](https://user-images.githubusercontent.com/49411370/189190821-a17e89d4-4b10-47dc-b8df-5e8302961d7c.png)
(Показатель производительности является "плавающим" его нужно усреднять по возможности для адекватной оценки, остальные параметры стабильно показывают оценку - без рандома)
